### PR TITLE
Fixed that "Vector", "Vector_a2j_Number" and "i" was leaking to the global scope

### DIFF
--- a/Box2D.js
+++ b/Box2D.js
@@ -17,6 +17,8 @@
 */
 var Box2D = {};
 
+(function () {
+
 (function (a2j, undefined) {
 
    if(!(Object.prototype.defineProperty instanceof Function)
@@ -10864,3 +10866,5 @@ Box2D.postDefs = [];
 var i;
 for (i = 0; i < Box2D.postDefs.length; ++i) Box2D.postDefs[i]();
 delete Box2D.postDefs;
+
+})();


### PR DESCRIPTION
It's in the title. 

The only thing that is done, is putting the initialization code in a self-executing anonymous function. 
